### PR TITLE
Replace AUTH0_AUDIENCE with API_IDENTIFIER

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ require('dotenv').config();
 
 chai.use(chaiHttp);
 
-if (!process.env.AUTH0_DOMAIN || !process.env.AUTH0_AUDIENCE || !process.env.API_URL
+if (!process.env.AUTH0_DOMAIN || !process.env.API_IDENTIFIER || !process.env.API_URL
     || !process.env.AUTH0_CLIENT_ID_1 || !process.env.AUTH0_CLIENT_SECRET_1
     || !process.env.AUTH0_CLIENT_ID_2 || !process.env.AUTH0_CLIENT_SECRET_2
     || !process.env.AUTH0_CLIENT_ID_3 || !process.env.AUTH0_CLIENT_SECRET_3
@@ -19,7 +19,7 @@ const getToken = function(clientId, clientSecret) {
   tokenRequestBody = {
     'client_id': clientId,
     'client_secret': clientSecret,
-    'audience': process.env.AUTH0_AUDIENCE,
+    'audience': process.env.API_IDENTIFIER,
     'grant_type': 'client_credentials'
   }
 


### PR DESCRIPTION
We are using API_IDENTIFIER for the audience in API Quickstarts